### PR TITLE
Typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- `Config` and `readConfig` type definitions updated
+
 ## [2.1.4][] - 2021-05-20
 
 - First release `metaconfiguration`, previously `@metarhia/config`

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -7,18 +7,11 @@ interface ConfigOptions {
   sandbox?: vm.Context;
 }
 
-export class Config {
-  sections: object;
-  path: string;
-  names: Array<string> | null;
-  mode: string;
-  context: vm.Context;
+export class Config<T = object> extends Promise<T> {
   constructor(dirPath: string, options?: ConfigOptions);
-  load(): Promise<object>;
-  loadFile(file: string): Promise<void>;
 }
 
-export function readConfig(
+export function readConfig<T = object>(
   dirPath: string,
   options?: ConfigOptions
-): Promise<Config>;
+): Promise<T>;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -10,7 +10,7 @@ interface ConfigOptions {
 export class Config {
   sections: object;
   path: string;
-  names: Array<string>;
+  names: Array<string> | null;
   mode: string;
   context: vm.Context;
   constructor(dirPath: string, options?: ConfigOptions);


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
it possible to add the following test to approve typing changes
but in my opinion we should not do this becouse of this test contains unhandled promises
```js
metatests.test('Type checking', async (test) => {
  const configInstance = new Config('./examples/example5');
  test.strictSame(configInstance instanceof Config, false);
  test.strictSame(configInstance instanceof Promise, true);

  const readedConfig = await readConfig('./examples/example1');
  test.strictSame(readedConfig instanceof Config, false);
  test.end();
});
```
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings

Of couse the Config instance contains "names" and "load" entries
but code-users cant call it because of the Config constructor do not returns a Config instance.

Also typescript show an error on new Config().then call
because of this method does not described at old type definition

Also the awaited readConfig result is not an instance of Config in fact.