### PR TITLE
Drop support of options `{ sandbox }` in 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Drop support of options `{ sandbox }` use `{ context }` instead
+
 ## [2.2.0][] - 2023-10-27
 
 - Drop node 16 and 19, add node 21 support

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Use custom context (sandbox) to execute configuration js file in it:
 const vm = require('node:vm');
 const metautil = require('metautil');
 const { Config } = require('metaconfiguration');
-const sandbox = { Duration: metautil.duration };
-vm.createContext(sandbox);
-const options = { sandbox };
+const context = { duration: metautil.duration };
+vm.createContext(context);
+const options = { context };
 const config = await new Config('./configDirectory', options);
 ```
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -4,7 +4,6 @@ interface ConfigOptions {
   names?: Array<string>;
   mode?: string;
   context?: vm.Context;
-  sandbox?: vm.Context;
 }
 
 export class Config {

--- a/config.js
+++ b/config.js
@@ -6,12 +6,12 @@ const fsp = require('node:fs').promises;
 
 class Config {
   constructor(dirPath, options = {}) {
-    const { names, mode, context, sandbox } = options;
+    const { names, mode, context } = options;
     this.sections = {};
     this.path = dirPath;
     this.names = names || null;
     this.mode = mode || '';
-    this.context = context || sandbox || metavm.createContext();
+    this.context = context || metavm.createContext();
     return this.load();
   }
 


### PR DESCRIPTION
Closes: https://github.com/metarhia/metaconfiguration/issues/70

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
